### PR TITLE
Zsh improvements

### DIFF
--- a/zsh/configs/editor.zsh
+++ b/zsh/configs/editor.zsh
@@ -1,2 +1,2 @@
-export VISUAL=vim
+export VISUAL="code --wait"
 export EDITOR=$VISUAL

--- a/zsh/configs/history.zsh
+++ b/zsh/configs/history.zsh
@@ -1,6 +1,6 @@
-setopt hist_ignore_all_dups inc_append_history
+setopt hist_ignore_all_dups inc_append_history hist_ignore_space share_history
 HISTFILE=~/.zhistory
-HISTSIZE=4096
-SAVEHIST=4096
+HISTSIZE=10000
+SAVEHIST=10000
 
 export ERL_AFLAGS="-kernel shell_history enabled"

--- a/zshrc
+++ b/zshrc
@@ -1,10 +1,23 @@
-# load custom executable functions
+# ==============================================================================
+# ZSH Configuration
+# ==============================================================================
+# This file is the main zsh configuration entry point.
+# It loads modular configs from ~/.zsh/configs/ in order: pre -> main -> post
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Custom Functions
+# ------------------------------------------------------------------------------
+# Load all custom executable functions from ~/.zsh/functions/
 for function in ~/.zsh/functions/*; do
   source $function
 done
 
-# extra files in ~/.zsh/configs/pre , ~/.zsh/configs , and ~/.zsh/configs/post
-# these are loaded first, second, and third, respectively.
+# ------------------------------------------------------------------------------
+# Modular Config Loading
+# ------------------------------------------------------------------------------
+# Load config files from ~/.zsh/configs/pre, ~/.zsh/configs, and ~/.zsh/configs/post
+# in that order. This allows for proper dependency management.
 _load_settings() {
   _dir="$1"
   if [ -d "$_dir" ]; then
@@ -34,51 +47,61 @@ _load_settings() {
 }
 _load_settings "$HOME/.zsh/configs"
 
-# Local config
+# ------------------------------------------------------------------------------
+# Local Overrides
+# ------------------------------------------------------------------------------
+# Machine-specific config that shouldn't be in version control
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
 
-# aliases
+# Shell aliases
 [[ -f ~/.aliases ]] && source ~/.aliases
 
+# ------------------------------------------------------------------------------
+# FZF - Fuzzy Finder
+# ------------------------------------------------------------------------------
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 
-# tabtab source for packages
-# uninstall by removing these lines
+# ------------------------------------------------------------------------------
+# Tab Completions (tabtab)
+# ------------------------------------------------------------------------------
 [[ -f ~/.config/tabtab/__tabtab.zsh ]] && . ~/.config/tabtab/__tabtab.zsh || true
 
-## z
+# ------------------------------------------------------------------------------
+# Zsh Plugins
+# ------------------------------------------------------------------------------
+# z - Jump to frequently used directories
 source ~/.zsh/zsh-z/zsh-z.plugin.zsh
 
-## zsh-autosuggestions
+# zsh-autosuggestions - Fish-like autosuggestions
 source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
 
-## zsh-syntax-highlighting
+# zsh-syntax-highlighting - Syntax highlighting for commands (load last)
 source ~/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
 
-export NVM_DIR="$HOME/.nvm"
-[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
-[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-
-## Set JAVA HOME
+# ------------------------------------------------------------------------------
+# ASDF Version Manager - Language Runtimes
+# ------------------------------------------------------------------------------
+# Java - Set JAVA_HOME automatically based on asdf version
 source ~/.asdf/plugins/java/set-java-home.zsh
 
-## Android SDK paths
+# Golang - Set Go environment variables
+. ~/.asdf/plugins/golang/set-env.zsh
+
+# ------------------------------------------------------------------------------
+# Android SDK
+# ------------------------------------------------------------------------------
 export ANDROID_HOME=$HOME/Library/Android/sdk
 export PATH=$PATH:$ANDROID_HOME/emulator
 export PATH=$PATH:$ANDROID_HOME/tools
 export PATH=$PATH:$ANDROID_HOME/tools/bin
 export PATH=$PATH:$ANDROID_HOME/platform-tools
 
-## Set Rust path
-source ~/.asdf/installs/rust/1.57.0/env
+# ------------------------------------------------------------------------------
+# Bun - JavaScript Runtime
+# ------------------------------------------------------------------------------
+# Bun completions
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
 
-export PATH=$PATH:~/.asdf/installs/rust/1.57.0/bin
-export RUSTUP_HOME=$PATH:~/.asdf/installs/rust/1.57.0/bin
-# bun completions
-[ -s "~/.bun/_bun" ] && source "~/.bun/_bun"
-
-# bun
+# Bun path
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
-
-. ~/.asdf/plugins/golang/set-env.zsh


### PR DESCRIPTION
This PR implements improvements to the Zsh configuration. These changes improve performance, usability, and maintainability.

### Changes Made

- **Removed Unused NVM Code**: Eliminated NVM-related exports and sourcing from `zshrc` since ASDF is used instead, reducing unnecessary loading and potential conflicts.
- **Fixed Rust Path Management**: Removed hardcoded Rust version (1.57.0) and incorrect `RUSTUP_HOME` export, allowing ASDF to dynamically manage Rust installations.
- **Updated Editor to VS Code**: Changed `VISUAL` and `EDITOR` from `vim` to `code --wait` in `zsh/configs/editor.zsh` to align with primary editor usage.
- **Fixed Bun Completions**: Corrected the Bun completion sourcing path by removing unnecessary quotes in `zshrc`.

### ZSH improvements
- **Enhanced History Settings**: Increased `HISTSIZE` and `SAVEHIST` to 10,000 in `zsh/configs/history.zsh` for better command history retention.
- **Added History Options**: Enabled `hist_ignore_space` (ignores commands starting with space) and `share_history` (shared history across sessions) for improved history management.